### PR TITLE
Add CST ASCII far-field reader, loader, and plotting support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ target/
 .idea/
 .vscode/launch.json
 AntPat.code-workspace
+
+# macOS Finder
+.DS_Store

--- a/antpat/io/CST_FF_ASCII.py
+++ b/antpat/io/CST_FF_ASCII.py
@@ -1,0 +1,122 @@
+"""Read CST far-field exports stored as ASCII text tables."""
+
+import os
+import re
+
+import numpy as np
+
+
+_FREQ_RE = re.compile(r"\(f\s*=\s*([-+0-9.eE]+)\)")
+_FREQ_UNIT_SCALE = {
+    'hz': 1.0,
+    'khz': 1.0e3,
+    'mhz': 1.0e6,
+    'ghz': 1.0e9,
+}
+
+
+class CST_FF_ASCII(object):
+    """Represents one CST far-field exported as an ASCII text table."""
+
+    def __init__(self, fn=None, freq=None, freq_unit='MHz'):
+        self.header = []
+        self.theta = None
+        self.phi = None
+        self.abs_e = None
+        self.etheta = None
+        self.ephi = None
+        self.axial_ratio = None
+        self.freq = None
+        self.freq_unit = freq_unit
+        if fn is not None:
+            self.read(fn, freq=freq, freq_unit=freq_unit)
+
+    def _infer_frequency(self, filename, freq=None, freq_unit='MHz'):
+        if freq is None:
+            match = _FREQ_RE.search(os.path.basename(filename))
+            if match is None:
+                raise ValueError(
+                    "Could not infer frequency from filename {}; pass freq explicitly"
+                    .format(filename)
+                )
+            freq = float(match.group(1))
+        scale = _FREQ_UNIT_SCALE.get(freq_unit.lower())
+        if scale is None:
+            raise ValueError("Unsupported frequency unit {}".format(freq_unit))
+        self.freq_unit = freq_unit
+        return float(freq) * scale
+
+    def _read_data_rows(self, filename):
+        data_rows = []
+        in_data = False
+        with open(filename, 'r') as handle:
+            for line in handle:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                if not in_data:
+                    self.header.append(stripped)
+                    if set(stripped) == {'-'}:
+                        in_data = True
+                    continue
+                data_rows.append([float(value) for value in stripped.split()])
+        if not data_rows:
+            raise ValueError("No CST far-field samples found in {}".format(filename))
+        data = np.asarray(data_rows, dtype=float)
+        if data.shape[1] < 7:
+            raise ValueError(
+                "Expected at least 7 columns in CST far-field table, got {}"
+                .format(data.shape[1])
+            )
+        return data
+
+    def read(self, filename, freq=None, freq_unit='MHz'):
+        """Read a CST ASCII text far-field export."""
+        self.header = []
+        data = self._read_data_rows(filename)
+        theta_deg = data[:, 0]
+        phi_deg = data[:, 1]
+        abs_e = data[:, 2]
+        abs_etheta = data[:, 3]
+        phase_etheta_deg = data[:, 4]
+        abs_ephi = data[:, 5]
+        phase_ephi_deg = data[:, 6]
+        axial_ratio = data[:, 7] if data.shape[1] > 7 else None
+
+        theta_count = np.unique(theta_deg).size
+        phi_count = np.unique(phi_deg).size
+        expected_size = theta_count * phi_count
+        if data.shape[0] != expected_size:
+            raise ValueError(
+                "CST far-field grid is incomplete: got {} samples for {}x{} grid"
+                .format(data.shape[0], theta_count, phi_count)
+            )
+
+        grid_shape = (theta_count, phi_count)
+        self.theta = theta_deg.reshape(grid_shape, order='F')
+        self.phi = phi_deg.reshape(grid_shape, order='F')
+        self.abs_e = abs_e.reshape(grid_shape, order='F')
+        self.etheta = (
+            abs_etheta * np.exp(1j * np.deg2rad(phase_etheta_deg))
+        ).reshape(grid_shape, order='F')
+        self.ephi = (
+            abs_ephi * np.exp(1j * np.deg2rad(phase_ephi_deg))
+        ).reshape(grid_shape, order='F')
+        if axial_ratio is not None:
+            self.axial_ratio = axial_ratio.reshape(grid_shape, order='F')
+        else:
+            self.axial_ratio = None
+        self.freq = self._infer_frequency(filename, freq=freq, freq_unit=freq_unit)
+        return self
+
+
+def load_cst_radpat(filename, freq=None, freq_unit='MHz'):
+    """Load a CST ASCII text far-field export into a RadFarField."""
+    from antpat.radfarfield import RadFarField
+    from antpat.reps.sphgridfun import tvecfun
+
+    cst_ff = CST_FF_ASCII(filename, freq=freq, freq_unit=freq_unit)
+    tvfd = tvecfun.TVecFields()
+    tvfd._full_init(np.deg2rad(cst_ff.theta), np.deg2rad(cst_ff.phi),
+                    cst_ff.etheta, cst_ff.ephi, R=cst_ff.freq)
+    return RadFarField(tvfd)

--- a/antpat/io/CST_FF_ASCII.py
+++ b/antpat/io/CST_FF_ASCII.py
@@ -7,6 +7,7 @@ import numpy as np
 
 
 _FREQ_RE = re.compile(r"\(f\s*=\s*([-+0-9.eE]+)\)")
+_COMPONENT_RE = re.compile(r"(?:abs|phase)\(([^)]+)\)")
 _FREQ_UNIT_SCALE = {
     'hz': 1.0,
     'khz': 1.0e3,
@@ -16,9 +17,16 @@ _FREQ_UNIT_SCALE = {
 
 
 class CST_FF_ASCII(object):
-    """Represents one CST far-field exported as an ASCII text table."""
+    """Represents one CST far-field exported as an ASCII text table.
 
-    def __init__(self, fn=None, freq=None, freq_unit='MHz'):
+    The angular grid is inferred from the theta and phi columns in degrees.
+    The vector basis is detected from the header when possible:
+    Theta/Phi implies spherical polar components and U/V implies Ludwig3.
+    If the header is absent or ambiguous, the default is basisType='polar'.
+    Pass basisType='polar' or basisType='Ludwig3' to override detection.
+    """
+
+    def __init__(self, fn=None, freq=None, freq_unit='MHz', basisType=None):
         self.header = []
         self.theta = None
         self.phi = None
@@ -26,10 +34,83 @@ class CST_FF_ASCII(object):
         self.etheta = None
         self.ephi = None
         self.axial_ratio = None
+        self.F1 = None
+        self.F2 = None
+        self.theta_values = None
+        self.phi_values = None
+        self.theta_step = None
+        self.phi_step = None
         self.freq = None
         self.freq_unit = freq_unit
+        self.basisType = None
         if fn is not None:
-            self.read(fn, freq=freq, freq_unit=freq_unit)
+            self.read(fn, freq=freq, freq_unit=freq_unit, basisType=basisType)
+
+    def _normalize_basis_type(self, basisType):
+        if basisType is None:
+            return None
+        lowered = basisType.lower()
+        if lowered == 'polar':
+            return 'polar'
+        if lowered == 'ludwig3':
+            return 'Ludwig3'
+        raise ValueError("Unsupported basisType {}".format(basisType))
+
+    def _infer_basis_type(self, basisType=None):
+        normalized_basis = self._normalize_basis_type(basisType)
+        if normalized_basis is not None:
+            return normalized_basis
+        if not self.header:
+            return 'polar'
+        normalized_header = self.header[0].lower().replace(' ', '')
+        components = _COMPONENT_RE.findall(normalized_header)
+        transverse_components = []
+        for component in components:
+            normalized_component = component.strip().lower()
+            if normalized_component == 'e':
+                continue
+            if normalized_component not in transverse_components:
+                transverse_components.append(normalized_component)
+        if len(transverse_components) >= 2:
+            comp0 = transverse_components[0]
+            comp1 = transverse_components[1]
+            if comp0 == 'theta' and comp1 == 'phi':
+                return 'polar'
+            if comp0 == 'u' and comp1 == 'v':
+                return 'Ludwig3'
+        return 'polar'
+
+    def _infer_axis(self, values_deg, axis_name):
+        axis_values = np.unique(values_deg)
+        if axis_values.size == 0:
+            raise ValueError("No {} samples found".format(axis_name))
+        if axis_values.size == 1:
+            axis_step = None
+        else:
+            axis_steps = np.diff(axis_values)
+            axis_step = float(axis_steps[0])
+            if not np.allclose(axis_steps, axis_step):
+                raise ValueError(
+                    "{} grid is not regularly spaced: {}"
+                    .format(axis_name, axis_steps)
+                )
+        return axis_values, axis_step
+
+    def _gridify(self, theta_deg, phi_deg, values, theta_values, phi_values):
+        theta_count = theta_values.size
+        phi_count = phi_values.size
+        grid_shape = (theta_count, phi_count)
+        theta_idx = np.searchsorted(theta_values, theta_deg)
+        phi_idx = np.searchsorted(phi_values, phi_deg)
+        grid = np.empty(grid_shape, dtype=values.dtype)
+        filled = np.zeros(grid_shape, dtype=bool)
+        if np.any(filled[theta_idx, phi_idx]):
+            raise ValueError("CST far-field grid contains duplicate theta/phi samples")
+        grid[theta_idx, phi_idx] = values
+        filled[theta_idx, phi_idx] = True
+        if not np.all(filled):
+            raise ValueError("CST far-field grid is incomplete after theta/phi mapping")
+        return grid
 
     def _infer_frequency(self, filename, freq=None, freq_unit='MHz'):
         if freq is None:
@@ -70,10 +151,26 @@ class CST_FF_ASCII(object):
             )
         return data
 
-    def read(self, filename, freq=None, freq_unit='MHz'):
-        """Read a CST ASCII text far-field export."""
+    def read(self, filename, freq=None, freq_unit='MHz', basisType=None):
+        """Read a CST ASCII text far-field export.
+
+        Parameters
+        ----------
+        filename : str
+            CST ASCII far-field filename.
+        freq : float, optional
+            Frequency value to use when it should not be inferred from the
+            filename.
+        freq_unit : str, optional
+            Unit associated with freq when it is provided explicitly.
+        basisType : {'polar', 'Ludwig3'}, optional
+            Override the vector basis declared by the header. If omitted, the
+            basis is inferred from the header and falls back to 'polar' when
+            the header is absent or ambiguous.
+        """
         self.header = []
         data = self._read_data_rows(filename)
+        self.basisType = self._infer_basis_type(basisType)
         theta_deg = data[:, 0]
         phi_deg = data[:, 1]
         abs_e = data[:, 2]
@@ -83,8 +180,10 @@ class CST_FF_ASCII(object):
         phase_ephi_deg = data[:, 6]
         axial_ratio = data[:, 7] if data.shape[1] > 7 else None
 
-        theta_count = np.unique(theta_deg).size
-        phi_count = np.unique(phi_deg).size
+        theta_values, theta_step = self._infer_axis(theta_deg, 'Theta')
+        phi_values, phi_step = self._infer_axis(phi_deg, 'Phi')
+        theta_count = theta_values.size
+        phi_count = phi_values.size
         expected_size = theta_count * phi_count
         if data.shape[0] != expected_size:
             raise ValueError(
@@ -92,31 +191,50 @@ class CST_FF_ASCII(object):
                 .format(data.shape[0], theta_count, phi_count)
             )
 
-        grid_shape = (theta_count, phi_count)
-        self.theta = theta_deg.reshape(grid_shape, order='F')
-        self.phi = phi_deg.reshape(grid_shape, order='F')
-        self.abs_e = abs_e.reshape(grid_shape, order='F')
-        self.etheta = (
-            abs_etheta * np.exp(1j * np.deg2rad(phase_etheta_deg))
-        ).reshape(grid_shape, order='F')
-        self.ephi = (
-            abs_ephi * np.exp(1j * np.deg2rad(phase_ephi_deg))
-        ).reshape(grid_shape, order='F')
+        self.theta_values = theta_values
+        self.phi_values = phi_values
+        self.theta_step = theta_step
+        self.phi_step = phi_step
+
+        theta_grid, phi_grid = np.meshgrid(theta_values, phi_values, indexing='ij')
+        self.theta = theta_grid
+        self.phi = phi_grid
+        self.abs_e = self._gridify(theta_deg, phi_deg, abs_e,
+                                   theta_values, phi_values)
+        self.F1 = self._gridify(
+            theta_deg, phi_deg,
+            abs_etheta * np.exp(1j * np.deg2rad(phase_etheta_deg)),
+            theta_values, phi_values
+        )
+        self.F2 = self._gridify(
+            theta_deg, phi_deg,
+            abs_ephi * np.exp(1j * np.deg2rad(phase_ephi_deg)),
+            theta_values, phi_values
+        )
+        self.etheta = self.F1
+        self.ephi = self.F2
         if axial_ratio is not None:
-            self.axial_ratio = axial_ratio.reshape(grid_shape, order='F')
+            self.axial_ratio = self._gridify(theta_deg, phi_deg, axial_ratio,
+                                             theta_values, phi_values)
         else:
             self.axial_ratio = None
         self.freq = self._infer_frequency(filename, freq=freq, freq_unit=freq_unit)
         return self
 
 
-def load_cst_radpat(filename, freq=None, freq_unit='MHz'):
-    """Load a CST ASCII text far-field export into a RadFarField."""
+def load_cst_radpat(filename, freq=None, freq_unit='MHz', basisType=None):
+    """Load a CST ASCII text far-field export into a RadFarField.
+
+    basisType defaults to 'polar' when the CST header does not identify the
+    component basis explicitly.
+    """
     from antpat.radfarfield import RadFarField
     from antpat.reps.sphgridfun import tvecfun
 
-    cst_ff = CST_FF_ASCII(filename, freq=freq, freq_unit=freq_unit)
+    cst_ff = CST_FF_ASCII(filename, freq=freq, freq_unit=freq_unit,
+                          basisType=basisType)
     tvfd = tvecfun.TVecFields()
     tvfd._full_init(np.deg2rad(cst_ff.theta), np.deg2rad(cst_ff.phi),
-                    cst_ff.etheta, cst_ff.ephi, R=cst_ff.freq)
+                    cst_ff.F1, cst_ff.F2, R=cst_ff.freq,
+                    basisType=cst_ff.basisType)
     return RadFarField(tvfd)

--- a/antpat/reps/sphgridfun/tvecfun.py
+++ b/antpat/reps/sphgridfun/tvecfun.py
@@ -61,14 +61,21 @@ class TVecFields(object):
             self.Fthetas = numpy.delete(self.Fthetas, -1, 2)
             self.Fphis = numpy.delete(self.Fphis, -1, 2)
 
-    def load_cst(self, filename, freq=None, freq_unit='MHz'):
-        """Read a CST text far-field export into this vector field."""
-        cstfile = CST_FF_ASCII(filename, freq=freq, freq_unit=freq_unit)
-        self.R = cstfile.freq
-        self.thetaMsh = numpy.deg2rad(cstfile.theta)
-        self.phiMsh = numpy.deg2rad(cstfile.phi)
-        self.Fthetas = cstfile.etheta
-        self.Fphis = cstfile.ephi
+    def load_cst(self, filename, freq=None, freq_unit='MHz', basisType=None):
+        """Read a CST text far-field export into this vector field.
+
+        Parameters
+        ----------
+        basisType : {'polar', 'Ludwig3'}, optional
+            Override the basis declared by the CST header. If omitted, the
+            loader detects the basis from the header and defaults to 'polar'
+            when the header is absent or ambiguous.
+        """
+        cstfile = CST_FF_ASCII(filename, freq=freq, freq_unit=freq_unit,
+                               basisType=basisType)
+        self._full_init(numpy.deg2rad(cstfile.theta), numpy.deg2rad(cstfile.phi),
+                        cstfile.F1, cstfile.F2, R=cstfile.freq,
+                        basisType=cstfile.basisType)
 
     def save_ffe(self, filename, request='FarField', source='Unknown'):
         """ """
@@ -357,10 +364,16 @@ def plotFEKO(filename, request=None, freq_req=None):
                 projection='orthographic')
 
 
-def plotCST(filename, freq=None, freq_unit='MHz', projection='orthographic'):
-    """Convenience function that reads a CST far-field text export and plots it."""
+def plotCST(filename, freq=None, freq_unit='MHz', projection='orthographic',
+            basisType=None):
+    """Convenience function that reads a CST far-field text export and plots it.
+
+    basisType may be set to 'polar' or 'Ludwig3'. If omitted, the basis is
+    detected from the CST header and defaults to 'polar' when ambiguous.
+    """
     tvf = TVecFields()
-    tvf.load_cst(filename, freq=freq, freq_unit=freq_unit)
+    tvf.load_cst(filename, freq=freq, freq_unit=freq_unit,
+                 basisType=basisType)
     freq_hz = tvf.getRs()
     print("Frequency={}".format(freq_hz))
     THETA = tvf.getthetas()

--- a/antpat/reps/sphgridfun/tvecfun.py
+++ b/antpat/reps/sphgridfun/tvecfun.py
@@ -4,6 +4,7 @@ import numpy.ma
 import datetime
 from scipy.interpolate import RegularGridInterpolator
 import matplotlib.pyplot as plt
+from antpat.io.CST_FF_ASCII import CST_FF_ASCII
 from antpat.io.feko_ffe import FEKOffe, FEKOffeRequest
 from .pntsonsphere import sph2crtISO
 
@@ -59,6 +60,15 @@ class TVecFields(object):
             self.phiMsh = numpy.delete(self.phiMsh, -1, 1)
             self.Fthetas = numpy.delete(self.Fthetas, -1, 2)
             self.Fphis = numpy.delete(self.Fphis, -1, 2)
+
+    def load_cst(self, filename, freq=None, freq_unit='MHz'):
+        """Read a CST text far-field export into this vector field."""
+        cstfile = CST_FF_ASCII(filename, freq=freq, freq_unit=freq_unit)
+        self.R = cstfile.freq
+        self.thetaMsh = numpy.deg2rad(cstfile.theta)
+        self.phiMsh = numpy.deg2rad(cstfile.phi)
+        self.Fthetas = cstfile.etheta
+        self.Fphis = cstfile.ephi
 
     def save_ffe(self, filename, request='FarField', source='Unknown'):
         """ """
@@ -345,6 +355,20 @@ def plotFEKO(filename, request=None, freq_req=None):
                                 tvf.getFthetas(freq), tvf.getFphis(freq))
     plotvfonsph(THETA, PHI, E_th, E_ph, freq, vcoord='Ludwig3',
                 projection='orthographic')
+
+
+def plotCST(filename, freq=None, freq_unit='MHz', projection='orthographic'):
+    """Convenience function that reads a CST far-field text export and plots it."""
+    tvf = TVecFields()
+    tvf.load_cst(filename, freq=freq, freq_unit=freq_unit)
+    freq_hz = tvf.getRs()
+    print("Frequency={}".format(freq_hz))
+    THETA = tvf.getthetas()
+    PHI = tvf.getphis()
+    E_th = tvf.getFthetas(freq_hz)
+    E_ph = tvf.getFphis(freq_hz)
+    plotvfonsph(THETA, PHI, E_th, E_ph, freq_hz, vcoordlist=['sph'],
+                projection=projection)
 
 
 # TobiaC (2013-06-17)

--- a/tests/test_CST_FF_ASCII.py
+++ b/tests/test_CST_FF_ASCII.py
@@ -1,0 +1,50 @@
+import os
+import unittest
+
+import numpy as np
+
+from antpat.io.CST_FF_ASCII import CST_FF_ASCII, load_cst_radpat
+
+
+class CSTFFASCIITests(unittest.TestCase):
+    def setUp(self):
+        root_dir = os.path.dirname(os.path.dirname(__file__))
+        self.sample = os.path.join(root_dir, 'share', 'CST', 'farfield (f=60) [1].txt')
+
+    def test_parse_cst_table(self):
+        cst_ff = CST_FF_ASCII(self.sample)
+        self.assertEqual(cst_ff.theta.shape, (181, 360))
+        self.assertEqual(cst_ff.phi.shape, (181, 360))
+        self.assertAlmostEqual(cst_ff.freq, 60.0e6)
+        self.assertAlmostEqual(cst_ff.theta[0, 0], 0.0)
+        self.assertAlmostEqual(cst_ff.theta[-1, 0], 180.0)
+        self.assertAlmostEqual(cst_ff.phi[0, 0], 0.0)
+        self.assertAlmostEqual(cst_ff.phi[0, -1], 359.0)
+        self.assertAlmostEqual(np.abs(cst_ff.etheta[0, 0]), 3.731, places=3)
+        self.assertAlmostEqual(np.abs(cst_ff.ephi[0, 0]), 3.729, places=3)
+
+    def test_load_tvecfields_from_cst(self):
+        from antpat.reps.sphgridfun.tvecfun import TVecFields
+
+        tvf = TVecFields()
+        tvf.load_cst(self.sample)
+
+        self.assertAlmostEqual(tvf.getRs(), 60.0e6)
+        self.assertEqual(tvf.getthetas().shape, (181, 360))
+        self.assertEqual(tvf.getphis().shape, (181, 360))
+        self.assertAlmostEqual(np.abs(tvf.getFthetas()[0, 0]), 3.731, places=3)
+        self.assertAlmostEqual(np.abs(tvf.getFphis()[0, 0]), 3.729, places=3)
+
+    def test_load_radfarfield_from_cst(self):
+        radpat = load_cst_radpat(self.sample)
+        freqs = radpat.getfreqs()
+        self.assertAlmostEqual(freqs, 60.0e6)
+        theta, phi, e_th, e_ph = radpat.getFFongrid(freqs)
+        self.assertEqual(theta.shape, (181, 360))
+        self.assertEqual(phi.shape, (181, 360))
+        self.assertAlmostEqual(np.abs(e_th[0, 0]), 3.731, places=3)
+        self.assertAlmostEqual(np.abs(e_ph[0, 0]), 3.729, places=3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_CST_FF_ASCII.py
+++ b/tests/test_CST_FF_ASCII.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 
 import numpy as np
@@ -11,17 +12,107 @@ class CSTFFASCIITests(unittest.TestCase):
         root_dir = os.path.dirname(os.path.dirname(__file__))
         self.sample = os.path.join(root_dir, 'share', 'CST', 'farfield (f=60) [1].txt')
 
+    def _write_cst_file(self, filepath, header, rows):
+        with open(filepath, 'w') as handle:
+            handle.write(header + '\n')
+            handle.write('-' * max(len(header), 30) + '\n')
+            for row in rows:
+                handle.write(' '.join(str(value) for value in row) + '\n')
+
     def test_parse_cst_table(self):
         cst_ff = CST_FF_ASCII(self.sample)
         self.assertEqual(cst_ff.theta.shape, (181, 360))
         self.assertEqual(cst_ff.phi.shape, (181, 360))
         self.assertAlmostEqual(cst_ff.freq, 60.0e6)
+        self.assertEqual(cst_ff.basisType, 'polar')
+        self.assertAlmostEqual(cst_ff.theta_step, 1.0)
+        self.assertAlmostEqual(cst_ff.phi_step, 1.0)
         self.assertAlmostEqual(cst_ff.theta[0, 0], 0.0)
         self.assertAlmostEqual(cst_ff.theta[-1, 0], 180.0)
         self.assertAlmostEqual(cst_ff.phi[0, 0], 0.0)
         self.assertAlmostEqual(cst_ff.phi[0, -1], 359.0)
         self.assertAlmostEqual(np.abs(cst_ff.etheta[0, 0]), 3.731, places=3)
         self.assertAlmostEqual(np.abs(cst_ff.ephi[0, 0]), 3.729, places=3)
+
+    def test_parse_generic_regular_mesh(self):
+        rows = [
+            (10.0, 5.0, 0.5, 0.25, -30.0, 0.1, 15.0, 0.5),
+            (10.0, 15.0, 1.0, 0.5, 0.0, 0.2, 90.0, 1.0),
+            (0.0, 5.0, 2.0, 1.0, 180.0, 0.5, 0.0, 2.0),
+            (5.0, 10.0, 3.0, 1.5, 90.0, 0.7, -90.0, 3.0),
+            (5.0, 15.0, 3.5, 1.75, 60.0, 0.9, -60.0, 3.5),
+            (0.0, 15.0, 4.0, 2.0, 45.0, 1.0, 180.0, 4.0),
+            (0.0, 10.0, 4.5, 2.25, 10.0, 1.2, -10.0, 4.5),
+            (10.0, 10.0, 5.0, 2.5, 30.0, 1.5, 45.0, 5.0),
+            (5.0, 5.0, 6.0, 3.0, -45.0, 2.0, 30.0, 6.0),
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = os.path.join(tmpdir, 'farfield (f=10) [1].txt')
+            header = ('Theta [deg.] Phi [deg.] Abs(E)[V/m] Abs(Theta)[V/m] '
+                      'Phase(Theta)[deg.] Abs(Phi)[V/m] Phase(Phi)[deg.] Ax.Ratio')
+            self._write_cst_file(filepath, header, rows)
+
+            cst_ff = CST_FF_ASCII(filepath)
+
+        self.assertEqual(cst_ff.theta.shape, (3, 3))
+        self.assertEqual(cst_ff.phi.shape, (3, 3))
+        self.assertAlmostEqual(cst_ff.theta_step, 5.0)
+        self.assertAlmostEqual(cst_ff.phi_step, 5.0)
+        np.testing.assert_allclose(cst_ff.theta[:, 0], [0.0, 5.0, 10.0])
+        np.testing.assert_allclose(cst_ff.phi[0, :], [5.0, 10.0, 15.0])
+        self.assertAlmostEqual(np.abs(cst_ff.etheta[2, 2]), 0.5, places=12)
+        self.assertAlmostEqual(np.angle(cst_ff.ephi[2, 2], deg=True), 90.0, places=12)
+
+    def test_detect_ludwig3_from_header(self):
+        rows = [
+            (0.0, 0.0, 1.0, 1.0, 0.0, 2.0, 90.0, 1.0),
+            (0.0, 90.0, 1.0, 1.5, 0.0, 0.5, 180.0, 1.0),
+            (90.0, 0.0, 1.0, 2.0, 45.0, 1.0, 0.0, 1.0),
+            (90.0, 90.0, 1.0, 0.75, -45.0, 1.25, 30.0, 1.0),
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = os.path.join(tmpdir, 'farfield (f=20) [1].txt')
+            header = ('Theta [deg.] Phi [deg.] Abs(E)[V/m] Abs(U)[V/m] '
+                      'Phase(U)[deg.] Abs(V)[V/m] Phase(V)[deg.] Ax.Ratio')
+            self._write_cst_file(filepath, header, rows)
+
+            cst_ff = CST_FF_ASCII(filepath)
+
+        self.assertEqual(cst_ff.basisType, 'Ludwig3')
+        self.assertAlmostEqual(np.abs(cst_ff.F1[0, 0]), 1.0)
+        self.assertAlmostEqual(np.abs(cst_ff.F2[0, 0]), 2.0)
+
+    def test_explicit_basis_type_override(self):
+        rows = [
+            (0.0, 0.0, 1.0, 1.0, 0.0, 2.0, 90.0, 1.0),
+            (0.0, 90.0, 1.0, 1.5, 0.0, 0.5, 180.0, 1.0),
+            (90.0, 0.0, 1.0, 2.0, 45.0, 1.0, 0.0, 1.0),
+            (90.0, 90.0, 1.0, 0.75, -45.0, 1.25, 30.0, 1.0),
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = os.path.join(tmpdir, 'farfield (f=20) [1].txt')
+            header = 'Theta [deg.] Phi [deg.] Abs(E)[V/m] Comp1 Comp2'
+            self._write_cst_file(filepath, header, rows)
+
+            cst_ff = CST_FF_ASCII(filepath, basisType='Ludwig3')
+
+        self.assertEqual(cst_ff.basisType, 'Ludwig3')
+
+    def test_ambiguous_header_defaults_to_polar(self):
+        rows = [
+            (0.0, 0.0, 1.0, 1.0, 0.0, 2.0, 90.0, 1.0),
+            (0.0, 90.0, 1.0, 1.5, 0.0, 0.5, 180.0, 1.0),
+            (90.0, 0.0, 1.0, 2.0, 45.0, 1.0, 0.0, 1.0),
+            (90.0, 90.0, 1.0, 0.75, -45.0, 1.25, 30.0, 1.0),
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = os.path.join(tmpdir, 'farfield (f=20) [1].txt')
+            header = 'Theta [deg.] Phi [deg.] Abs(E)[V/m] Comp1 Comp2'
+            self._write_cst_file(filepath, header, rows)
+
+            cst_ff = CST_FF_ASCII(filepath)
+
+        self.assertEqual(cst_ff.basisType, 'polar')
 
     def test_load_tvecfields_from_cst(self):
         from antpat.reps.sphgridfun.tvecfun import TVecFields
@@ -34,6 +125,29 @@ class CSTFFASCIITests(unittest.TestCase):
         self.assertEqual(tvf.getphis().shape, (181, 360))
         self.assertAlmostEqual(np.abs(tvf.getFthetas()[0, 0]), 3.731, places=3)
         self.assertAlmostEqual(np.abs(tvf.getFphis()[0, 0]), 3.729, places=3)
+
+    def test_load_tvecfields_from_ludwig3_cst(self):
+        from antpat.reps.sphgridfun.tvecfun import TVecFields, Ludwig32sph
+
+        rows = [
+            (0.0, 90.0, 1.0, 1.5, 0.0, 0.5, 180.0, 1.0),
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = os.path.join(tmpdir, 'farfield (f=20) [1].txt')
+            header = ('Theta [deg.] Phi [deg.] Abs(E)[V/m] Abs(U)[V/m] '
+                      'Phase(U)[deg.] Abs(V)[V/m] Phase(V)[deg.] Ax.Ratio')
+            self._write_cst_file(filepath, header, rows)
+
+            tvf = TVecFields()
+            tvf.load_cst(filepath)
+
+        eu = 1.5 + 0.0j
+        ev = 0.5 * np.exp(1j * np.deg2rad(180.0))
+        expected_eth, expected_eph = Ludwig32sph(np.deg2rad(np.array([[90.0]])),
+                                                 np.array([[eu]]), np.array([[ev]]))
+        self.assertAlmostEqual(tvf.getRs(), 20.0e6)
+        self.assertAlmostEqual(tvf.getFthetas()[0, 0], expected_eth[0, 0])
+        self.assertAlmostEqual(tvf.getFphis()[0, 0], expected_eph[0, 0])
 
     def test_load_radfarfield_from_cst(self):
         radpat = load_cst_radpat(self.sample)


### PR DESCRIPTION
This PR adds CST ASCII far-field support to AntPat.

Changes included:
- new CST ASCII reader
- loading into TVecFields and RadFarField
- plotCST helper
- automatic angular mesh inference from theta/phi columns
- automatic basis detection from CST headers (Theta/Phi or U/V)
- explicit basis override with basisType='polar' or basisType='Ludwig3'
- default fallback to polar when the header is ambiguous
- targeted unit tests

Validation:
.venv/bin/python -m unittest discover -s tests -p 'test_CST_FF_ASCII.py'

Result:
8 tests passed